### PR TITLE
DX: Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ composer require tomasvotruba/finalize --dev
 1. First run command, that detects parent classes, entities etc.
 
 ```bash
-vendor/bin/finalize detect src tests
+vendor/bin/finalize detect src/ tests/
 ```
 
 It will generate `.finalize.json` files with all found classes, that should be skipped.


### PR DESCRIPTION
the trailling slashes in the command args help a developer new to the tool, to identify which args passed to the tool are just "magic strings" like `detect` and which are regular filesystem paths, like `src/ tests/` in this example